### PR TITLE
Store middleclass library in ikkuna.class variable

### DIFF
--- a/src/gui/display.lua
+++ b/src/gui/display.lua
@@ -1,4 +1,4 @@
-local Display = class('Display')
+local Display = ikkuna.class('Display')
 
 function Display:initialize()
 	local styles = ikkuna.Styles:new()

--- a/src/gui/event.lua
+++ b/src/gui/event.lua
@@ -1,4 +1,4 @@
-local Event = class('Event')
+local Event = ikkuna.class('Event')
 
 function Event:initialize()
 	self.callbacks = {}

--- a/src/gui/widget.lua
+++ b/src/gui/widget.lua
@@ -1,4 +1,4 @@
-local Widget = class('Widget')
+local Widget = ikkuna.class('Widget')
 Widget.LastId = 0
 Widget.PressInterval = 0.25
 

--- a/src/ikkuna.lua
+++ b/src/ikkuna.lua
@@ -1,8 +1,6 @@
-if not class then
-	class = require('vendor.middleclass')
-end
-
 ikkuna = {}
+ikkuna.class = require('vendor.middleclass')
+
 ikkuna.font = love.graphics.newFont('res/Verdana.ttf')
 
 -- Const

--- a/src/layout/horizontal.lua
+++ b/src/layout/horizontal.lua
@@ -1,4 +1,4 @@
-local HorizontalLayout = class('HorizontalLayout', ikkuna.Layout)
+local HorizontalLayout = ikkuna.class('HorizontalLayout', ikkuna.Layout)
 
 function HorizontalLayout:initialize(options)
 	local options = options or {}

--- a/src/layout/layout.lua
+++ b/src/layout/layout.lua
@@ -1,4 +1,4 @@
-local Layout = class('Layout')
+local Layout = ikkuna.class('Layout')
 
 function Layout:initialize(parent)
 	self.parent = parent

--- a/src/layout/vertical.lua
+++ b/src/layout/vertical.lua
@@ -1,4 +1,4 @@
-local VerticalLayout = class('VerticalLayout', ikkuna.Layout)
+local VerticalLayout = ikkuna.class('VerticalLayout', ikkuna.Layout)
 
 function VerticalLayout:initialize(options)
 	local options = options or {}

--- a/src/style/lexer.lua
+++ b/src/style/lexer.lua
@@ -1,4 +1,4 @@
-local Lexer = class('StyleLexer')
+local Lexer = ikkuna.class('StyleLexer')
 local Token = ikkuna.StyleToken
 
 Lexer.Whitespace = {' ', '\n', '\t'}

--- a/src/style/parser.lua
+++ b/src/style/parser.lua
@@ -1,4 +1,4 @@
-local Parser = class('StyleParser')
+local Parser = ikkuna.class('StyleParser')
 local Token = ikkuna.StyleToken
 
 function Parser:initialize(lexer)

--- a/src/style/stream.lua
+++ b/src/style/stream.lua
@@ -1,4 +1,4 @@
-local Stream = class('StyleStream')
+local Stream = ikkuna.class('StyleStream')
 
 function Stream:initialize()
 	self.path = ''

--- a/src/style/styles.lua
+++ b/src/style/styles.lua
@@ -1,4 +1,4 @@
-local Styles = class('Styles')
+local Styles = ikkuna.class('Styles')
 
 function Styles:initialize()
 	self.styles = {}

--- a/src/style/token.lua
+++ b/src/style/token.lua
@@ -1,4 +1,4 @@
-local Token = class('StyleToken')
+local Token = ikkuna.class('StyleToken')
 
 Token.Type = {}
 Token.Type.Unknown = 1

--- a/src/util/timer.lua
+++ b/src/util/timer.lua
@@ -1,4 +1,4 @@
-local Timer = class('timer')
+local Timer = ikkuna.class('timer')
 
 function Timer:initialize()
 	self.time = love.timer.getTime()

--- a/src/widgets/button.lua
+++ b/src/widgets/button.lua
@@ -1,4 +1,4 @@
-local Button = class('Button', ikkuna.Widget)
+local Button = ikkuna.class('Button', ikkuna.Widget)
 
 function Button:initialize()
 	ikkuna.Widget.initialize(self)

--- a/src/widgets/checkbox.lua
+++ b/src/widgets/checkbox.lua
@@ -1,4 +1,4 @@
-local CheckBox = class('CheckBox', ikkuna.Widget)
+local CheckBox = ikkuna.class('CheckBox', ikkuna.Widget)
 
 function CheckBox:initialize()
 	ikkuna.Widget.initialize(self)

--- a/src/widgets/combobox.lua
+++ b/src/widgets/combobox.lua
@@ -1,4 +1,4 @@
-local ComboBox = class('ComboBox', ikkuna.Widget)
+local ComboBox = ikkuna.class('ComboBox', ikkuna.Widget)
 
 function ComboBox:initialize(options)
 	ikkuna.Widget.initialize(self)

--- a/src/widgets/label.lua
+++ b/src/widgets/label.lua
@@ -1,4 +1,4 @@
-local Label = class('Label', ikkuna.Widget)
+local Label = ikkuna.class('Label', ikkuna.Widget)
 
 function Label:initialize()
 	ikkuna.Widget.initialize(self)

--- a/src/widgets/progressbar.lua
+++ b/src/widgets/progressbar.lua
@@ -1,4 +1,4 @@
-local ProgressBar = class('ProgressBar', ikkuna.Widget)
+local ProgressBar = ikkuna.class('ProgressBar', ikkuna.Widget)
 
 function ProgressBar:initialize()
 	ikkuna.Widget.initialize(self)

--- a/src/widgets/pushbutton.lua
+++ b/src/widgets/pushbutton.lua
@@ -1,4 +1,4 @@
-local PushButton = class('PushButton', ikkuna.Button)
+local PushButton = ikkuna.class('PushButton', ikkuna.Button)
 
 function PushButton:initialize()
 	ikkuna.Button.initialize(self)

--- a/src/widgets/radiobox.lua
+++ b/src/widgets/radiobox.lua
@@ -1,4 +1,4 @@
-local RadioBox = class('RadioBox', ikkuna.Widget)
+local RadioBox = ikkuna.class('RadioBox', ikkuna.Widget)
 RadioBox.Segments = 20
 
 function RadioBox:initialize()

--- a/src/widgets/radiogroup.lua
+++ b/src/widgets/radiogroup.lua
@@ -1,4 +1,4 @@
-local RadioGroup = class('RadioGroup')
+local RadioGroup = ikkuna.class('RadioGroup')
 
 function RadioGroup:initialize()
 	self.children = {}

--- a/src/widgets/spinbox.lua
+++ b/src/widgets/spinbox.lua
@@ -1,4 +1,4 @@
-local SpinBox = class('SpinBox', ikkuna.Widget)
+local SpinBox = ikkuna.class('SpinBox', ikkuna.Widget)
 
 function SpinBox:initialize(min, max)
 	ikkuna.Widget.initialize(self)

--- a/src/widgets/textinput.lua
+++ b/src/widgets/textinput.lua
@@ -1,4 +1,4 @@
-local TextInput = class('TextInput', ikkuna.Widget)
+local TextInput = ikkuna.class('TextInput', ikkuna.Widget)
 
 function TextInput:initialize(options)
 	ikkuna.Widget.initialize(self)


### PR DESCRIPTION
This prevents overriding the global class variable that may be used by projects importing the library.